### PR TITLE
Modify task leaderboard to work for submissions missing characterCount

### DIFF
--- a/backend/controllers/submissionController.js
+++ b/backend/controllers/submissionController.js
@@ -128,9 +128,26 @@ const getTaskLeaderboard = async (req, res) => {
   }
 
   const submissions = await SubmissionModel.aggregate([
-    { $match: { parentTask: new ObjectId(competition.tasks[0]._id) } },
-    { $match: { score: { $gt: 0 } } },
-    { $sort: { score: -1, characterCount: 1, executionTime: 1 } },
+    {
+      $match: {
+        parentTask: new ObjectId(competition.tasks[0]._id),
+        score: { $gt: 0 },
+      },
+    },
+    {
+      // Compat: Documents before codeCharacterCount and time was added won't sort correctly
+      hasCharCount: {
+        $cond: [{ $gt: ['$codeCharacterCount', 0] }, true, false],
+      },
+    },
+    {
+      $sort: {
+        score: -1,
+        hasCharCount: -1,
+        characterCount: 1,
+        executionTime: 1,
+      },
+    },
     {
       $group: {
         _id: '$user',


### PR DESCRIPTION
Fixes an issue where scores missing `codeCharacterCount` and `executionTime` were always sorted first.